### PR TITLE
Teacher mode + UI stability fixes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -49,7 +49,8 @@ export default function App() {
   }, [clearHistory]);
 
   const canSwap = canSwapSelector(state);
-  const canUndo = historyLen > 0 && state.status !== "setup" && state.status !== "thinking";
+  const hasUndoHistory = historyLen > 0 && state.status !== "setup";
+  const canUndo = hasUndoHistory && state.status !== "thinking";
   const bothAI = !state.redIsHuman && !state.blueIsHuman;
   const canStep = bothAI && state.paused && state.status === "thinking";
 
@@ -153,7 +154,6 @@ export default function App() {
       style={{
         display: "flex",
         flexDirection: "column",
-        minHeight: "100vh",
         alignItems: "center",
         padding: "20px 16px 32px",
       }}
@@ -165,7 +165,7 @@ export default function App() {
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          marginBottom: 20,
+          marginBottom: 16,
           animation: "fadeUp 0.35s ease",
         }}
       >
@@ -207,9 +207,7 @@ export default function App() {
         style={{
           width: "100%",
           maxWidth: BOARD_MAX_WIDTH,
-          flex: 1,
           display: "flex",
-          alignItems: "center",
           justifyContent: "center",
         }}
       >
@@ -230,7 +228,7 @@ export default function App() {
 
       <div
         style={{
-          marginTop: 20,
+          marginTop: 16,
           width: "100%",
           maxWidth: BOARD_MAX_WIDTH,
           animation: "fadeUp 0.35s ease 0.1s both",
@@ -254,6 +252,7 @@ export default function App() {
           showRatings={state.showRatings}
           teacherMode={state.teacherMode}
           showTeacher={showTeacher}
+          hasUndoHistory={hasUndoHistory}
           canUndo={canUndo}
           bothAI={bothAI}
           paused={state.paused}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,6 +2,7 @@ import { useReducer, useMemo, useRef, useState, useEffect, useCallback } from "r
 import { gameReducer, initialState, canSwap as canSwapSelector, GameState } from "./game/state";
 import { useAI } from "./hooks/useAI";
 import { findWinningPath, Player } from "./game/rules";
+import { classifyMoveQuality } from "./game/teacher";
 import HexBoard from "./components/HexBoard";
 import Controls from "./components/Controls";
 import PlayerSetup from "./components/PlayerSetup";
@@ -62,6 +63,25 @@ export default function App() {
     return stones % 2 === 0 ? "0" : "1";
   }, [state.cells]);
 
+  const teacherQuality = useMemo(
+    () =>
+      state.teacherMode && state.teacherMoveId !== null
+        ? classifyMoveQuality(state.teacherScores, state.cells, state.teacherMoveId)
+        : null,
+    [state.teacherMode, state.teacherScores, state.teacherMoveId, state.cells]
+  );
+
+  // Show a "analyzing…" hint when teacher mode is on but we have nothing to
+  // render yet — typically the first cold-start inference, or when the user
+  // moves faster than the worker can respond.
+  const teacherLoading =
+    state.teacherMode &&
+    teacherQuality === null &&
+    state.pendingTeacherScores === null &&
+    state.status === "idle";
+
+  const showTeacher = state.redIsHuman || state.blueIsHuman;
+
   // Global hotkeys — skip when an input/textarea has focus.
   useEffect(() => {
     if (state.status === "setup") return;
@@ -83,6 +103,9 @@ export default function App() {
       } else if (k === "s") {
         e.preventDefault();
         dispatch({ type: "TOGGLE_RATINGS" });
+      } else if (k === "t" && showTeacher) {
+        e.preventDefault();
+        dispatch({ type: "TOGGLE_TEACHER" });
       } else if (k === "p" && bothAI) {
         e.preventDefault();
         dispatch({ type: "TOGGLE_PAUSE" });
@@ -93,7 +116,7 @@ export default function App() {
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [state.status, canUndo, bothAI, canStep, handleUndo, handleReset, handleRestart]);
+  }, [state.status, canUndo, bothAI, canStep, showTeacher, handleUndo, handleReset, handleRestart]);
 
   function handleCellClick(id: number) {
     if (canSwap && state.cells[id] !== null) {
@@ -198,6 +221,9 @@ export default function App() {
           lastMove={state.lastMove}
           status={state.status}
           winningPath={winningPath}
+          teacherMode={state.teacherMode}
+          teacherScores={state.teacherScores}
+          teacherMoveId={state.teacherMoveId}
           onCellClick={handleCellClick}
         />
       </div>
@@ -221,9 +247,13 @@ export default function App() {
           blueIsHuman={state.blueIsHuman}
           canSwap={canSwap}
           aiSwapped={state.aiSwapped}
+          teacherQuality={teacherQuality}
+          teacherLoading={teacherLoading}
         />
         <Controls
           showRatings={state.showRatings}
+          teacherMode={state.teacherMode}
+          showTeacher={showTeacher}
           canUndo={canUndo}
           bothAI={bothAI}
           paused={state.paused}
@@ -232,6 +262,7 @@ export default function App() {
           onReset={handleReset}
           onRestart={handleRestart}
           onToggleRatings={() => dispatch({ type: "TOGGLE_RATINGS" })}
+          onToggleTeacher={() => dispatch({ type: "TOGGLE_TEACHER" })}
           onTogglePause={() => dispatch({ type: "TOGGLE_PAUSE" })}
           onStep={() => dispatch({ type: "STEP" })}
         />

--- a/app/src/components/Controls.tsx
+++ b/app/src/components/Controls.tsx
@@ -2,6 +2,8 @@ import { ReactNode, useState } from "react";
 
 interface ControlsProps {
   showRatings: boolean;
+  teacherMode: boolean;
+  showTeacher: boolean;
   canUndo: boolean;
   bothAI: boolean;
   paused: boolean;
@@ -10,12 +12,15 @@ interface ControlsProps {
   onReset: () => void;
   onRestart: () => void;
   onToggleRatings: () => void;
+  onToggleTeacher: () => void;
   onTogglePause: () => void;
   onStep: () => void;
 }
 
 export default function Controls({
   showRatings,
+  teacherMode,
+  showTeacher,
   canUndo,
   bothAI,
   paused,
@@ -24,6 +29,7 @@ export default function Controls({
   onReset,
   onRestart,
   onToggleRatings,
+  onToggleTeacher,
   onTogglePause,
   onStep,
 }: ControlsProps) {
@@ -160,6 +166,32 @@ export default function Controls({
         </svg>
         Ratings
       </IconBtn>
+      {showTeacher && (
+        <IconBtn
+          onClick={onToggleTeacher}
+          active={teacherMode}
+          testId="toggle-teacher"
+          title="Highlight blunders and better moves"
+          hotkey="T"
+        >
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 14 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <circle cx="7" cy="4" r="2.5" />
+            <path d="M2 13c0-2.76 2.24-5 5-5s5 2.24 5 5" />
+            <path d="M10 7.5l1.5 1-1.5 1" />
+          </svg>
+          Teacher
+        </IconBtn>
+      )}
     </div>
   );
 }

--- a/app/src/components/Controls.tsx
+++ b/app/src/components/Controls.tsx
@@ -4,6 +4,7 @@ interface ControlsProps {
   showRatings: boolean;
   teacherMode: boolean;
   showTeacher: boolean;
+  hasUndoHistory: boolean;
   canUndo: boolean;
   bothAI: boolean;
   paused: boolean;
@@ -21,6 +22,7 @@ export default function Controls({
   showRatings,
   teacherMode,
   showTeacher,
+  hasUndoHistory,
   canUndo,
   bothAI,
   paused,
@@ -91,8 +93,14 @@ export default function Controls({
           Step
         </IconBtn>
       )}
-      {canUndo && (
-        <IconBtn onClick={onUndo} testId="undo" title="Undo" hotkey="U">
+      {hasUndoHistory && (
+        <IconBtn
+          onClick={onUndo}
+          testId="undo"
+          title="Undo"
+          hotkey="U"
+          disabled={!canUndo}
+        >
           <svg
             width="13"
             height="13"

--- a/app/src/components/HexBoard.tsx
+++ b/app/src/components/HexBoard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { BOARD_SIZE } from "../game/constants";
 import { posToId } from "../game/coords";
 import { Cell } from "../game/rules";
+import { getTopSuggestions, Suggestion } from "../game/teacher";
 import HexCell from "./HexCell";
 
 // Pointy-top hex geometry
@@ -44,6 +45,9 @@ interface HexBoardProps {
   lastMove: number | null;
   status: "idle" | "thinking" | "gameover";
   winningPath: Set<number> | null;
+  teacherMode: boolean;
+  teacherScores: (number | null)[] | null;
+  teacherMoveId: number | null;
   onCellClick: (id: number) => void;
 }
 
@@ -55,10 +59,25 @@ export default function HexBoard({
   lastMove,
   status,
   winningPath,
+  teacherMode,
+  teacherScores,
+  teacherMoveId,
   onCellClick,
 }: HexBoardProps) {
   const canClick = status === "idle";
   const swapTargetId = canSwap ? cells.findIndex((c) => c !== null) : -1;
+
+  const teacherSuggestionMap = useMemo(() => {
+    if (!teacherMode || teacherMoveId === null) return new Map<number, Suggestion>();
+    const suggestions = getTopSuggestions(teacherScores, cells, teacherMoveId, 3);
+    return new Map(suggestions.map((s) => [s.id, s]));
+  }, [teacherMode, teacherScores, teacherMoveId, cells]);
+
+  const suggestionColor = useMemo(() => {
+    if (teacherMoveId === null) return null;
+    const player = cells[teacherMoveId];
+    return player === "0" ? RED_FILL : player === "1" ? BLUE_FILL : null;
+  }, [cells, teacherMoveId]);
 
   const viewBox = useMemo(() => {
     const borderCenters: [number, number][] = [];
@@ -126,6 +145,11 @@ export default function HexBoard({
               isLastMove={id === lastMove}
               isOnWinningPath={winningPath?.has(id) ?? false}
               isSwapTarget={id === swapTargetId}
+              teacherPlayedScore={
+                id === teacherMoveId && teacherScores ? (teacherScores[id] ?? null) : null
+              }
+              teacherSuggestion={teacherSuggestionMap.get(id) ?? null}
+              suggestionColor={suggestionColor}
               onClick={canClick ? onCellClick : undefined}
             />
           );

--- a/app/src/components/HexCell.tsx
+++ b/app/src/components/HexCell.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Cell } from "../game/rules";
+import { Suggestion } from "../game/teacher";
 
 const ANGLES = [30, 90, 150, 210, 270, 330].map((d) => (d * Math.PI) / 180);
 const R = 1;
@@ -27,8 +28,16 @@ interface HexCellProps {
   isLastMove?: boolean;
   isOnWinningPath?: boolean;
   isSwapTarget?: boolean;
+  /** Score to render on the played stone in teacher mode (regardless of showScore). */
+  teacherPlayedScore?: number | null;
+  /** Ghost marker on an empty cell the AI preferred. */
+  teacherSuggestion?: Suggestion | null;
+  /** Color used for ghost suggestions — the player who was choosing. */
+  suggestionColor?: string | null;
   onClick?: (id: number) => void;
 }
+
+const SUGGESTION_OPACITY = [0.95, 0.75, 0.55];
 
 export default function HexCell({
   cx,
@@ -40,15 +49,31 @@ export default function HexCell({
   isLastMove = false,
   isOnWinningPath = false,
   isSwapTarget = false,
+  teacherPlayedScore = null,
+  teacherSuggestion = null,
+  suggestionColor = null,
   onClick,
 }: HexCellProps) {
   const [hovered, setHovered] = useState(false);
   const stoneFill = cell === "0" ? RED_FILL : cell === "1" ? BLUE_FILL : null;
   const fill = stoneFill ?? (hovered && onClick ? EMPTY_HOVER : EMPTY_FILL);
-  const showLabel = showScore && score !== null && (cell === null || isLastMove);
-  const label = showLabel ? score.toFixed(1) : "";
+  // Teacher-mode score on the played stone always wins over the ratings label,
+  // since it's the frozen score from the player's own perspective at decision time.
+  const teacherScoreVisible = teacherPlayedScore != null && cell !== null;
+  const showLabel = teacherScoreVisible || (showScore && score !== null && (cell === null || isLastMove));
+  const label = teacherScoreVisible
+    ? teacherPlayedScore.toFixed(1)
+    : showLabel && score !== null
+      ? score.toFixed(1)
+      : "";
   const clickable = Boolean(onClick) && (cell === null || isSwapTarget);
   const labelColor = cell === null ? "#66666f" : "white";
+
+  const showSuggestion = teacherSuggestion !== null && cell === null && suggestionColor !== null;
+  const suggestionOpacity =
+    showSuggestion && teacherSuggestion
+      ? (SUGGESTION_OPACITY[teacherSuggestion.rank - 1] ?? 0.4)
+      : 0;
 
   return (
     <g
@@ -61,6 +86,29 @@ export default function HexCell({
       data-testid="hex-cell"
     >
       <polygon points={POINTS} fill={fill} stroke={STROKE} strokeWidth={0.07} />
+      {showSuggestion && teacherSuggestion && suggestionColor && (
+        <g style={{ pointerEvents: "none" }} data-testid="teacher-suggestion">
+          <polygon
+            points={POINTS}
+            fill={suggestionColor}
+            fillOpacity={suggestionOpacity * 0.18}
+            stroke={suggestionColor}
+            strokeWidth={0.09}
+            strokeOpacity={suggestionOpacity}
+            strokeDasharray="0.18,0.12"
+          />
+          <text
+            fontSize={0.5}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill={suggestionColor}
+            fillOpacity={suggestionOpacity}
+            style={{ userSelect: "none", fontFamily: "var(--mono)", fontWeight: 500 }}
+          >
+            {teacherSuggestion.score.toFixed(1)}
+          </text>
+        </g>
+      )}
       {isSwapTarget && (
         <polygon
           points={SWAP_POINTS}

--- a/app/src/components/StatusBanner.tsx
+++ b/app/src/components/StatusBanner.tsx
@@ -1,4 +1,5 @@
 import { Player } from "../game/rules";
+import { QualityAnnotation } from "../game/teacher";
 
 interface StatusBannerProps {
   status: "idle" | "thinking" | "gameover";
@@ -7,6 +8,8 @@ interface StatusBannerProps {
   blueIsHuman: boolean;
   canSwap: boolean;
   aiSwapped: boolean;
+  teacherQuality?: QualityAnnotation | null;
+  teacherLoading?: boolean;
 }
 
 /**
@@ -20,24 +23,34 @@ export default function StatusBanner({
   blueIsHuman,
   canSwap,
   aiSwapped,
+  teacherQuality = null,
+  teacherLoading = false,
 }: StatusBannerProps) {
-  const content = selectContent({ status, winner, redIsHuman, blueIsHuman, canSwap, aiSwapped });
+  const primary = selectPrimary({ status, winner, redIsHuman, blueIsHuman, canSwap, aiSwapped });
+  const coach = teacherQuality ? (
+    <TeacherCoachLine quality={teacherQuality} />
+  ) : teacherLoading ? (
+    <TeacherLoadingLine />
+  ) : null;
 
   return (
     <div
       style={{
         minHeight: 52,
         display: "flex",
+        flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
+        gap: 6,
       }}
     >
-      {content}
+      {primary}
+      {coach}
     </div>
   );
 }
 
-function selectContent(props: StatusBannerProps) {
+function selectPrimary(props: Omit<StatusBannerProps, "teacherQuality">) {
   const { status, winner, redIsHuman, blueIsHuman, canSwap, aiSwapped } = props;
 
   if (canSwap) {
@@ -102,6 +115,70 @@ function selectContent(props: StatusBannerProps) {
   }
 
   return null;
+}
+
+function TeacherCoachLine({ quality }: { quality: QualityAnnotation }) {
+  const borderColor = quality.color.replace(/\)$/, " / 0.35)");
+  const bgColor = quality.color.replace(/\)$/, " / 0.08)");
+  return (
+    <div
+      data-testid="teacher-coach"
+      style={{
+        display: "inline-flex",
+        alignItems: "baseline",
+        gap: 10,
+        textAlign: "center",
+        lineHeight: 1.4,
+        padding: "12px 20px",
+        borderRadius: 12,
+        border: `1px solid ${borderColor}`,
+        background: bgColor,
+      }}
+    >
+      <span style={{ color: quality.color, fontWeight: 600, fontSize: 18 }}>{quality.label}</span>
+      <span style={{ color: "var(--muted)", fontFamily: "var(--mono)", fontSize: 14 }}>
+        Δ {quality.delta.toFixed(2)}
+      </span>
+      {quality.label !== "Good" && (
+        <span style={{ color: "var(--muted2)", fontSize: 14 }}>
+          — better moves shown on board
+        </span>
+      )}
+    </div>
+  );
+}
+
+function TeacherLoadingLine() {
+  return (
+    <div
+      data-testid="teacher-loading"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 10,
+        textAlign: "center",
+        lineHeight: 1.4,
+        padding: "12px 20px",
+        borderRadius: 12,
+        border: "1px dashed var(--border)",
+        background: "var(--card)",
+        color: "var(--muted2)",
+        fontSize: 14,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: "var(--muted2)",
+          animation: "pulse 1.2s ease infinite",
+        }}
+      />
+      <span>Teacher is analyzing the position…</span>
+    </div>
+  );
 }
 
 function Banner({

--- a/app/src/game/__tests__/state.test.ts
+++ b/app/src/game/__tests__/state.test.ts
@@ -306,3 +306,99 @@ describe("RESET", () => {
     expect(state.cells.every((c) => c === null)).toBe(true);
   });
 });
+
+describe("teacher mode", () => {
+  function scoresWithBest(bestId: number, bestVal = 2.5, otherVal = -1): Float32Array {
+    const s = new Float32Array(NUM_CELLS);
+    for (let i = 0; i < NUM_CELLS; i++) s[i] = otherVal;
+    s[bestId] = bestVal;
+    return s;
+  }
+
+  it("TOGGLE_TEACHER flips the flag and clears snapshots", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    expect(state.teacherMode).toBe(true);
+
+    state = gameReducer(state, { type: "TEACHER_SCORES", scores: scoresWithBest(0) });
+    expect(state.pendingTeacherScores).not.toBeNull();
+
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    expect(state.teacherMode).toBe(false);
+    expect(state.pendingTeacherScores).toBeNull();
+    expect(state.teacherScores).toBeNull();
+    expect(state.teacherMoveId).toBeNull();
+  });
+
+  it("TEACHER_SCORES is ignored when teacherMode is off", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TEACHER_SCORES", scores: scoresWithBest(0) });
+    expect(state.pendingTeacherScores).toBeNull();
+  });
+
+  it("PLAYER_MOVE snapshots pendingTeacherScores into teacherScores", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    state = gameReducer(state, { type: "TEACHER_SCORES", scores: scoresWithBest(5) });
+    expect(state.pendingTeacherScores?.[5]).toBeCloseTo(2.5);
+
+    state = gameReducer(state, { type: "PLAYER_MOVE", cellId: 3 });
+    expect(state.teacherMoveId).toBe(3);
+    expect(state.teacherScores?.[5]).toBeCloseTo(2.5);
+    expect(state.teacherScores?.[3]).toBeCloseTo(-1);
+    expect(state.pendingTeacherScores).toBeNull();
+  });
+
+  it("PLAYER_MOVE without pending scores leaves teacher fields null", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    state = gameReducer(state, { type: "PLAYER_MOVE", cellId: 3 });
+    expect(state.teacherMoveId).toBeNull();
+    expect(state.teacherScores).toBeNull();
+  });
+
+  it("AI_MOVE clears pendingTeacherScores", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    state = gameReducer(state, { type: "PLAYER_MOVE", cellId: 0 });
+    state = gameReducer(state, { type: "TEACHER_SCORES", scores: scoresWithBest(5) });
+    expect(state.pendingTeacherScores).not.toBeNull();
+
+    state = gameReducer(state, { type: "AI_MOVE", cellId: 1, scores: dummyScores() });
+    expect(state.pendingTeacherScores).toBeNull();
+  });
+
+  it("teacher annotation persists across AI turns until next PLAYER_MOVE", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    state = gameReducer(state, { type: "TEACHER_SCORES", scores: scoresWithBest(5) });
+    state = gameReducer(state, { type: "PLAYER_MOVE", cellId: 3 });
+    const annotatedMoveId = state.teacherMoveId;
+    state = gameReducer(state, { type: "AI_MOVE", cellId: 1, scores: dummyScores() });
+    expect(state.teacherMoveId).toBe(annotatedMoveId);
+    expect(state.teacherScores).not.toBeNull();
+  });
+
+  it("RESET preserves teacherMode", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    expect(state.teacherMode).toBe(true);
+    state = gameReducer(state, { type: "RESET" });
+    expect(state.teacherMode).toBe(true);
+    expect(state.pendingTeacherScores).toBeNull();
+    expect(state.teacherScores).toBeNull();
+  });
+
+  it("RESTART preserves teacherMode but clears annotations", () => {
+    let state = startedState();
+    state = gameReducer(state, { type: "TOGGLE_TEACHER" });
+    state = gameReducer(state, { type: "TEACHER_SCORES", scores: scoresWithBest(5) });
+    state = gameReducer(state, { type: "PLAYER_MOVE", cellId: 3 });
+    expect(state.teacherMoveId).toBe(3);
+
+    state = gameReducer(state, { type: "RESTART" });
+    expect(state.teacherMode).toBe(true);
+    expect(state.teacherMoveId).toBeNull();
+    expect(state.teacherScores).toBeNull();
+  });
+});

--- a/app/src/game/__tests__/teacher.test.ts
+++ b/app/src/game/__tests__/teacher.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { classifyMoveQuality, getTopSuggestions } from "../teacher";
+import { NUM_CELLS } from "../constants";
+
+function scoresFrom(map: Record<number, number>): (number | null)[] {
+  const s: (number | null)[] = Array(NUM_CELLS).fill(null);
+  for (const [k, v] of Object.entries(map)) s[Number(k)] = v;
+  return s;
+}
+
+function emptyCells(): (string | null)[] {
+  return Array(NUM_CELLS).fill(null);
+}
+
+describe("classifyMoveQuality", () => {
+  it("labels the top move as Good", () => {
+    const scores = scoresFrom({ 0: 2.0, 1: 0.0, 2: -1.5 });
+    const cells = emptyCells();
+    cells[0] = "0"; // just played cell 0
+    expect(classifyMoveQuality(scores, cells, 0)?.label).toBe("Good");
+  });
+
+  it("uses delta thresholds 0.5 / 1.5 / 3.0", () => {
+    const scores = scoresFrom({ 0: 3.0, 1: 2.6, 2: 1.6, 3: 0.1, 4: -1.0 });
+    const mk = (played: number) => {
+      const c = emptyCells();
+      c[played] = "0";
+      return c;
+    };
+    expect(classifyMoveQuality(scores, mk(1), 1)?.label).toBe("Good"); // Δ=0.4
+    expect(classifyMoveQuality(scores, mk(2), 2)?.label).toBe("Inaccuracy"); // Δ=1.4
+    expect(classifyMoveQuality(scores, mk(3), 3)?.label).toBe("Mistake"); // Δ=2.9
+    expect(classifyMoveQuality(scores, mk(4), 4)?.label).toBe("Blunder"); // Δ=4.0
+  });
+
+  it("returns null for missing scores", () => {
+    expect(classifyMoveQuality(null, emptyCells(), 0)).toBeNull();
+    expect(classifyMoveQuality(scoresFrom({}), emptyCells(), 5)).toBeNull();
+  });
+
+  it("ignores high scores on occupied cells", () => {
+    // Cell 0 has a huge score but is occupied by the opponent — it's not
+    // a legal move, so the played move at 1 should be the best available.
+    const scores = scoresFrom({ 0: 5.0, 1: 2.0, 2: 1.5 });
+    const cells = emptyCells();
+    cells[0] = "1"; // opponent stone
+    cells[1] = "0"; // just played
+    expect(classifyMoveQuality(scores, cells, 1)?.label).toBe("Good");
+    expect(classifyMoveQuality(scores, cells, 1)?.delta).toBeCloseTo(0);
+  });
+});
+
+describe("getTopSuggestions", () => {
+  it("only returns moves strictly better than the played move", () => {
+    const scores = scoresFrom({ 0: 2.0, 1: 1.5, 2: 0.0, 3: -0.3 });
+    const cells = emptyCells();
+    cells[0] = "0"; // pretend 0 was just played
+    const suggestions = getTopSuggestions(scores, cells, 0);
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it("returns up to n strictly-better empty cells, sorted by score", () => {
+    const scores = scoresFrom({ 0: 2.0, 1: 0.5, 2: 1.5, 3: -0.5, 4: 1.0, 5: 1.9 });
+    const cells = emptyCells();
+    cells[1] = "0"; // played cell 1 (score 0.5)
+    const suggestions = getTopSuggestions(scores, cells, 1, 3);
+    expect(suggestions.map((s) => s.id)).toEqual([0, 5, 2]);
+    expect(suggestions[0].rank).toBe(1);
+    expect(suggestions[1].rank).toBe(2);
+    expect(suggestions[2].rank).toBe(3);
+  });
+
+  it("skips already-occupied cells", () => {
+    const scores = scoresFrom({ 0: 3.0, 1: 2.0, 2: 1.0 });
+    const cells = emptyCells();
+    cells[0] = "1"; // occupied by opponent
+    cells[2] = "0"; // played move
+    const suggestions = getTopSuggestions(scores, cells, 2, 3);
+    expect(suggestions.map((s) => s.id)).toEqual([1]);
+  });
+});

--- a/app/src/game/state.ts
+++ b/app/src/game/state.ts
@@ -17,6 +17,13 @@ export interface GameState {
   lastMove: number | null;
   modelScores: (number | null)[];
   showRatings: boolean;
+  teacherMode: boolean;
+  /** Scores pre-computed for the current human-to-move position (null until inference lands). */
+  pendingTeacherScores: (number | null)[] | null;
+  /** Scores frozen at the moment of the last human move, used to annotate that move. */
+  teacherScores: (number | null)[] | null;
+  /** Cell id of the last human move annotated by teacher mode. */
+  teacherMoveId: number | null;
   status: "setup" | "idle" | "thinking" | "gameover";
   aiTurn: number;
   /** When true, AI turns won't auto-fire. Only meaningful in AI-vs-AI games. */
@@ -38,6 +45,8 @@ export type GameAction =
   | { type: "AI_MOVE"; cellId: number; scores: Float32Array }
   | { type: "AI_SURE_WIN"; cellId: number }
   | { type: "TOGGLE_RATINGS" }
+  | { type: "TOGGLE_TEACHER" }
+  | { type: "TEACHER_SCORES"; scores: Float32Array }
   | { type: "SET_TEMPERATURE"; player: Player; value: number }
   | { type: "TOGGLE_PAUSE" }
   | { type: "STEP" }
@@ -63,6 +72,10 @@ export function initialState(): GameState {
     lastMove: null,
     modelScores: Array<null>(NUM_CELLS).fill(null),
     showRatings: false,
+    teacherMode: false,
+    pendingTeacherScores: null,
+    teacherScores: null,
+    teacherMoveId: null,
     status: "setup",
     aiTurn: 0,
     paused: false,
@@ -136,6 +149,7 @@ function startGame(
   redTemperature: number,
   blueTemperature: number,
   showRatings: boolean,
+  teacherMode: boolean,
   prevAiTurn: number
 ): GameState {
   const agentIsBlue = redIsHuman;
@@ -151,6 +165,7 @@ function startGame(
     blueTemperature,
     agentIsBlue,
     showRatings,
+    teacherMode,
     status,
     aiTurn: status === "thinking" ? prevAiTurn + 1 : prevAiTurn,
     paused: bothAI,
@@ -166,6 +181,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         action.redTemperature,
         action.blueTemperature,
         state.showRatings,
+        state.teacherMode,
         state.aiTurn
       );
 
@@ -175,8 +191,13 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       const numMoves = state.cells.filter((c) => c !== null).length;
       const currentPlayer: Player = numMoves % 2 === 0 ? "0" : "1";
       const swapUsed = state.swapUsed || numMoves === 1;
+      // Freeze pre-computed teacher scores onto this move. If inference hasn't
+      // finished yet, leave teacherScores null — the annotation simply won't
+      // appear (and the pending inference will become stale and be discarded).
+      const teacherScores = state.teacherMode ? state.pendingTeacherScores : null;
+      const teacherMoveId = state.teacherMode && teacherScores !== null ? action.cellId : null;
       const next = placeStone(
-        { ...state, aiSwapped: false, swapUsed },
+        { ...state, aiSwapped: false, swapUsed, pendingTeacherScores: null, teacherScores, teacherMoveId },
         action.cellId,
         currentPlayer
       );
@@ -188,7 +209,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
     case "SWAP": {
       if (!canSwap(state)) return state;
-      return { ...state, ...applySwap(state), aiSwapped: false };
+      return { ...state, ...applySwap(state), aiSwapped: false, pendingTeacherScores: null };
     }
 
     case "AI_MOVE": {
@@ -197,14 +218,20 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       if (state.cells[action.cellId] !== null) {
         const numMoves = state.cells.filter((c) => c !== null).length;
         if (numMoves !== 1 || state.swapUsed) return state;
-        return { ...state, ...applySwap(state), aiSwapped: true, modelScores: scores };
+        return {
+          ...state,
+          ...applySwap(state),
+          aiSwapped: true,
+          modelScores: scores,
+          pendingTeacherScores: null,
+        };
       }
 
       const agentPlayer: Player = state.agentIsBlue ? "1" : "0";
       const numMoves = state.cells.filter((c) => c !== null).length;
       const swapUsed = state.swapUsed || numMoves === 1;
       const next = placeStone(
-        { ...state, modelScores: scores, aiSwapped: false, swapUsed },
+        { ...state, modelScores: scores, aiSwapped: false, swapUsed, pendingTeacherScores: null },
         action.cellId,
         agentPlayer
       );
@@ -219,7 +246,13 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       const numMoves = state.cells.filter((c) => c !== null).length;
       const swapUsed = state.swapUsed || numMoves === 1;
       const next = placeStone(
-        { ...state, modelScores: Array<null>(NUM_CELLS).fill(null), aiSwapped: false, swapUsed },
+        {
+          ...state,
+          modelScores: Array<null>(NUM_CELLS).fill(null),
+          aiSwapped: false,
+          swapUsed,
+          pendingTeacherScores: null,
+        },
         action.cellId,
         agentPlayer
       );
@@ -231,6 +264,21 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
     case "TOGGLE_RATINGS":
       return { ...state, showRatings: !state.showRatings };
+
+    case "TOGGLE_TEACHER":
+      return {
+        ...state,
+        teacherMode: !state.teacherMode,
+        pendingTeacherScores: null,
+        teacherScores: null,
+        teacherMoveId: null,
+      };
+
+    case "TEACHER_SCORES": {
+      if (!state.teacherMode) return state;
+      const scores = Array.from({ length: NUM_CELLS }, (_, i) => action.scores[i] ?? null);
+      return { ...state, pendingTeacherScores: scores };
+    }
 
     case "SET_TEMPERATURE": {
       const key = action.player === "0" ? "redTemperature" : "blueTemperature";
@@ -247,6 +295,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return {
         ...initialState(),
         showRatings: state.showRatings,
+        teacherMode: state.teacherMode,
         redTemperature: state.redTemperature,
         blueTemperature: state.blueTemperature,
       };
@@ -258,6 +307,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         state.redTemperature,
         state.blueTemperature,
         state.showRatings,
+        state.teacherMode,
         state.aiTurn
       );
 

--- a/app/src/game/teacher.ts
+++ b/app/src/game/teacher.ts
@@ -1,0 +1,79 @@
+export interface QualityTier {
+  label: "Good" | "Inaccuracy" | "Mistake" | "Blunder";
+  color: string;
+}
+
+export interface QualityAnnotation extends QualityTier {
+  delta: number;
+}
+
+export interface Suggestion {
+  id: number;
+  score: number;
+  rank: number;
+}
+
+export const TEACHER_THRESHOLDS: (QualityTier & { maxDelta: number })[] = [
+  { label: "Good",       maxDelta: 0.5,      color: "oklch(0.72 0.20 145)" },
+  { label: "Inaccuracy", maxDelta: 1.5,      color: "oklch(0.78 0.18 78)"  },
+  { label: "Mistake",    maxDelta: 3.0,      color: "oklch(0.72 0.20 48)"  },
+  { label: "Blunder",    maxDelta: Infinity, color: "oklch(0.65 0.25 15)"  },
+];
+
+function classifyDelta(delta: number): QualityAnnotation {
+  for (const t of TEACHER_THRESHOLDS) {
+    if (delta <= t.maxDelta) return { label: t.label, color: t.color, delta };
+  }
+  return { label: "Blunder", color: TEACHER_THRESHOLDS[3].color, delta };
+}
+
+export function classifyMoveQuality(
+  scores: (number | null)[] | null,
+  cells: (string | null)[],
+  playedId: number | null
+): QualityAnnotation | null {
+  if (!scores || playedId === null) return null;
+  const played = scores[playedId];
+  if (played == null) return null;
+  // `best` must be computed over moves that were *legal at decision time*:
+  // currently-empty cells, plus the played cell (which was empty then).
+  // The model emits a logit for every cell, so including occupied cells
+  // would let a meaningless score on e.g. an opponent's stone dominate.
+  let best = -Infinity;
+  for (let i = 0; i < scores.length; i++) {
+    if (cells[i] !== null && i !== playedId) continue;
+    const s = scores[i];
+    if (s != null && s > best) best = s;
+  }
+  if (!isFinite(best)) return null;
+  return classifyDelta(best - played);
+}
+
+/** Up to `n` empty cells the AI scored strictly higher than the played move. */
+export function getTopSuggestions(
+  scores: (number | null)[] | null,
+  cells: (string | null)[],
+  playedId: number | null,
+  n = 3
+): Suggestion[] {
+  if (!scores || playedId === null) return [];
+  const played = scores[playedId];
+  if (played == null) return [];
+
+  const candidates: { id: number; score: number }[] = [];
+  for (let i = 0; i < scores.length; i++) {
+    if (i === playedId) continue;
+    if (cells[i] !== null) continue;
+    const s = scores[i];
+    if (s == null) continue;
+    if (s <= played) continue;
+    candidates.push({ id: i, score: s });
+  }
+  candidates.sort((a, b) => b.score - a.score);
+
+  return candidates.slice(0, n).map((c, idx) => ({
+    id: c.id,
+    score: c.score,
+    rank: idx + 1,
+  }));
+}

--- a/app/src/hooks/useAI.ts
+++ b/app/src/hooks/useAI.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import { GameState, GameAction } from "../game/state";
 import { encodeBoard, averageOutputs } from "../game/encoding";
-import { findSureWinMove } from "../game/rules";
+import { findSureWinMove, Player } from "../game/rules";
 import { selectMove } from "../game/selectMove";
 import { MODEL_FILENAME } from "../game/constants";
 
@@ -22,6 +22,14 @@ function getWorker(): Worker {
 
 function createStateKey(state: GameState): string {
   return `${state.agentIsBlue}|${state.swapUsed ? "s" : "_"}|${state.cells.map((c) => c ?? "_").join("")}`;
+}
+
+function humanToMove(state: GameState): Player | null {
+  if (state.status !== "idle") return null;
+  const numMoves = state.cells.filter((c) => c !== null).length;
+  const nextPlayer: Player = numMoves % 2 === 0 ? "0" : "1";
+  const nextIsHuman = nextPlayer === "0" ? state.redIsHuman : state.blueIsHuman;
+  return nextIsHuman ? nextPlayer : null;
 }
 
 export function useAI(state: GameState, dispatch: React.Dispatch<GameAction>) {
@@ -80,6 +88,44 @@ export function useAI(state: GameState, dispatch: React.Dispatch<GameAction>) {
     );
   }, [dispatch]);
 
+  /** Pre-computes scores from the human-to-move's perspective for teacher mode. */
+  const handleTeacherTurn = useCallback(() => {
+    if (pendingRef.current) return;
+    const snapshot = stateRef.current;
+    const player = humanToMove(snapshot);
+    if (player === null) return;
+
+    pendingRef.current = true;
+    const { cells } = snapshot;
+    const playerIsBlue = player === "1";
+    const requestStateKey = createStateKey(snapshot);
+    const { input1, input2 } = encodeBoard(cells, playerIsBlue);
+    const worker = getWorker();
+
+    function onMessage(e: MessageEvent) {
+      const msg = e.data;
+      if (msg.type === "RESULT_PAIR") {
+        worker.removeEventListener("message", onMessage);
+        pendingRef.current = false;
+        const now = stateRef.current;
+        if (createStateKey(now) !== requestStateKey) return;
+        if (!now.teacherMode) return;
+        const scores = averageOutputs(msg.out1, msg.out2, playerIsBlue);
+        dispatch({ type: "TEACHER_SCORES", scores });
+      } else if (msg.type === "ERROR") {
+        worker.removeEventListener("message", onMessage);
+        pendingRef.current = false;
+        console.error("AI worker error:", msg.message);
+      }
+    }
+
+    worker.addEventListener("message", onMessage);
+    worker.postMessage(
+      { type: "INFER_PAIR", input1, input2, boardSize: 11, modelUrl: getModelUrl() },
+      [input1.buffer, input2.buffer]
+    );
+  }, [dispatch]);
+
   useEffect(() => {
     if (state.status === "thinking" && !state.paused) handleAITurn();
   }, [state.aiTurn, state.paused, handleAITurn]);
@@ -90,4 +136,19 @@ export function useAI(state: GameState, dispatch: React.Dispatch<GameAction>) {
     // Intentionally only depend on stepSignal: stepping runs one move on demand.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.stepSignal]);
+
+  useEffect(() => {
+    if (!state.teacherMode) return;
+    if (state.pendingTeacherScores !== null) return;
+    if (humanToMove(state) === null) return;
+    handleTeacherTurn();
+  }, [
+    state.teacherMode,
+    state.pendingTeacherScores,
+    state.status,
+    state.cells,
+    state.redIsHuman,
+    state.blueIsHuman,
+    handleTeacherTurn,
+  ]);
 }

--- a/tests/app_e2e/capture.spec.ts
+++ b/tests/app_e2e/capture.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const OUT_DIR = path.resolve(__dirname, "screenshots");
+
+test.use({ viewport: { width: 1280, height: 900 } });
+
+test("capture setup screen", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByTestId("start-game")).toBeVisible();
+  await page.waitForTimeout(400);
+  await page.screenshot({ path: path.join(OUT_DIR, "hexhex-setup.png") });
+});
+
+test("capture gameplay with ratings overlay", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByTestId("start-game").click();
+  await expect(page.getByTestId("hex-board")).toBeVisible();
+
+  // Let the worker + ONNX model finish loading on first use.
+  await page.waitForTimeout(1500);
+
+  const click = async (cellId: number) => {
+    const cell = page.locator(`[data-cell-id="${cellId}"]`);
+    if (await cell.count() === 0) return;
+    await cell.click();
+  };
+
+  // Human-vs-AI: human plays red. Play a handful of moves, giving the AI time to reply.
+  const myMoves = [60, 50, 72, 39, 84];
+  for (const id of myMoves) {
+    await click(id);
+    await page.waitForTimeout(1400);
+  }
+
+  // Toggle the move-values overlay (hotkey S).
+  await page.keyboard.press("s");
+  await expect(page.getByTestId("ratings-info")).toBeVisible();
+  await page.waitForTimeout(400);
+
+  await page.screenshot({ path: path.join(OUT_DIR, "hexhex-gameplay.png") });
+});


### PR DESCRIPTION
## Summary
- Add teacher mode for human turns: classifies each played move's quality (Good/Inaccuracy/Mistake/Blunder) against the model's scores, shows a coach line with the Δ, and renders up to 3 ghost alternatives on the board when the move isn't Good. Toggled with `T`; only offered in games with a human player.
- UI stability: drop the `flex: 1` vertical-centering slot around the board so it no longer drifts when the status banner changes height (swap hint, teacher coach line, AI-swap notice). Keep the Undo button mounted once there's history and disable it during AI thinking, instead of unmounting it — stops the controls row from reflowing every turn.
- Add an ad-hoc Playwright screenshot capture spec at `tests/app_e2e/capture.spec.ts` that writes `hexhex-setup.png` and `hexhex-gameplay.png` into `tests/app_e2e/screenshots/` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)